### PR TITLE
Swapped out the keys to reflect the actual gallium layout

### DIFF
--- a/Linux/gallium
+++ b/Linux/gallium
@@ -1,4 +1,3 @@
-
 default partial
 xkb_symbols "basic" {
     include "us(basic)"
@@ -10,29 +9,31 @@ xkb_symbols "basic" {
     key <AD03> {[ d, D ]};
     key <AD04> {[ c, C ]};
     key <AD05> {[ v, V ]};
-    key <AD06> {[ z, Z ]};
-    key <AD07> {[ y, Y ]};
+    key <AD06> {[ j, J ]};
+    key <AD07> {[ f, F ]};
     key <AD08> {[ o, O ]};
     key <AD09> {[ u, U ]};
     key <AD10> {[ comma, less ]};
+
     key <AC01> {[ n, N ]};
     key <AC02> {[ r, R ]};
     key <AC03> {[ t, T ]};
     key <AC04> {[ s, S ]};
     key <AC05> {[ g, G ]};
-    key <AC06> {[ p, P ]};
+    key <AC06> {[ y, Y ]};
     key <AC07> {[ h, H ]};
     key <AC08> {[ a, A ]};
     key <AC09> {[ e, E ]};
     key <AC10> {[ i, I ]};
     key <AC11> {[ slash, question ]};
-    key <AB01> {[ q, Q ]};
-    key <AB02> {[ x, X ]};
+
+    key <AB01> {[ x, X ]};
+    key <AB02> {[ q, Q ]};
     key <AB03> {[ m, M ]};
     key <AB04> {[ w, W ]};
-    key <AB05> {[ j, J ]};
+    key <AB05> {[ z, Z ]};
     key <AB06> {[ k, K ]};
-    key <AB07> {[ f, F ]};
+    key <AB07> {[ p, P ]};
     key <AB08> {[ apostrophe, quotedbl ]};
     key <AB09> {[ semicolon, colon ]};
     key <AB10> {[ period, greater ]};

--- a/Linux/gallium_angle
+++ b/Linux/gallium_angle
@@ -1,4 +1,3 @@
-
 default partial
 xkb_symbols "basic" {
     include "us(basic)"
@@ -9,28 +8,30 @@ xkb_symbols "basic" {
     key <AD02> {[ l, L ]};
     key <AD03> {[ d, D ]};
     key <AD04> {[ c, C ]};
-    key <AD05> {[ j, J ]};
-    key <AD06> {[ z, Z ]};
+    key <AD05> {[ v, V ]};
+    key <AD06> {[ j, J ]};
     key <AD07> {[ y, Y ]};
     key <AD08> {[ o, O ]};
     key <AD09> {[ u, U ]};
     key <AD10> {[ comma, less ]};
+
     key <AC01> {[ n, N ]};
     key <AC02> {[ r, R ]};
     key <AC03> {[ t, T ]};
     key <AC04> {[ s, S ]};
-    key <AC05> {[ v, V ]};
+    key <AC05> {[ g, G ]};
     key <AC06> {[ p, P ]};
     key <AC07> {[ h, H ]};
     key <AC08> {[ a, A ]};
     key <AC09> {[ e, E ]};
     key <AC10> {[ i, I ]};
     key <AC11> {[ slash, question ]};
+
     key <AB01> {[ x, X ]};
-    key <AB02> {[ m, M ]};
-    key <AB03> {[ w, W ]};
-    key <AB04> {[ g, G ]};
-    key <AB05> {[ q, Q ]};
+    key <AB02> {[ q, Q ]};
+    key <AB03> {[ m, M ]};
+    key <AB04> {[ w, W ]};
+    key <AB05> {[ z, Z ]};
     key <AB06> {[ k, K ]};
     key <AB07> {[ f, F ]};
     key <AB08> {[ apostrophe, quotedbl ]};


### PR DESCRIPTION
The keys in the Linux folder don't reflect the layout thats used everywhere else, so I just made a quick fix